### PR TITLE
fix: Remove the shared aws config

### DIFF
--- a/appstore/client.go
+++ b/appstore/client.go
@@ -241,7 +241,7 @@ func (client *AppStoreClient) deleteAppStoreListing(id string) error {
 }
 
 func BuildAppStoreClient() (*AppStoreClient, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithSharedConfigProfile("lifeomic-dev"))
+	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ locals {
 
 provider "appstore" {}
 
-resource "applet" "anxiety" {
+resource "applet" "terraform_test_applet" {
   provider       = appstore
   name           = var.name
   description    = var.description

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Anxiety Severity Assessment",
-  "name": "Anxiety Severity Assessment",
+  "name": "Terraform Test Applet",
   "icons": [
     {
       "src": "icon-240.png",


### PR DESCRIPTION
Now that the okta aws tool has been fixed we don't need to specify a profile anymore.
This makes running in different environments simpler.